### PR TITLE
feat: PostService와 LikeService JUnit 단위테스트 추가

### DIFF
--- a/src/test/java/com/run/runners/service/LikeServiceTest.java
+++ b/src/test/java/com/run/runners/service/LikeServiceTest.java
@@ -1,0 +1,156 @@
+package com.run.runners.service;
+
+import com.run.runners.entity.Like;
+import com.run.runners.entity.Post;
+import com.run.runners.repository.LikeRepository;
+import com.run.runners.repository.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LikeServiceTest {
+
+    @Mock
+    private LikeRepository likeRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private LikeService likeService;
+
+    private Post testPost;
+    private Like testLike;
+    private String userIdentifier;
+
+    @BeforeEach
+    void setUp() {
+        testPost = new Post();
+        testPost.setId(1L);
+        testPost.setTitle("테스트 제목");
+        testPost.setContent("테스트 내용");
+        testPost.setAuthor("테스트 작성자");
+        testPost.setViewCount(0);
+        testPost.setLikeCount(0);
+        testPost.setCreatedAt(LocalDateTime.now());
+        testPost.setUpdatedAt(LocalDateTime.now());
+
+        userIdentifier = "192.168.1.1";
+
+        testLike = new Like();
+        testLike.setId(1L);
+        testLike.setPost(testPost);
+        testLike.setUserIdentifier(userIdentifier);
+        testLike.setCreatedAt(LocalDateTime.now());
+    }
+
+    @Test
+    void toggleLike_WhenPostNotExists_ShouldThrowException() {
+        when(postRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            likeService.toggleLike(1L, userIdentifier);
+        });
+
+        verify(postRepository, times(1)).findById(1L);
+        verify(likeRepository, never()).existsByPostAndUserIdentifier(any(), any());
+    }
+
+    @Test
+    void toggleLike_WhenLikeNotExists_ShouldAddLike() {
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+        when(likeRepository.existsByPostAndUserIdentifier(testPost, userIdentifier)).thenReturn(false);
+        when(likeRepository.save(any(Like.class))).thenReturn(testLike);
+
+        boolean result = likeService.toggleLike(1L, userIdentifier);
+
+        assertTrue(result);
+        assertEquals(1, testPost.getLikeCount());
+        verify(postRepository, times(1)).findById(1L);
+        verify(likeRepository, times(1)).existsByPostAndUserIdentifier(testPost, userIdentifier);
+        verify(likeRepository, times(1)).save(any(Like.class));
+        verify(postRepository, times(1)).save(testPost);
+    }
+
+    @Test
+    void toggleLike_WhenLikeExists_ShouldRemoveLike() {
+        testPost.setLikeCount(1);
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+        when(likeRepository.existsByPostAndUserIdentifier(testPost, userIdentifier)).thenReturn(true);
+
+        boolean result = likeService.toggleLike(1L, userIdentifier);
+
+        assertFalse(result);
+        assertEquals(0, testPost.getLikeCount());
+        verify(postRepository, times(1)).findById(1L);
+        verify(likeRepository, times(1)).existsByPostAndUserIdentifier(testPost, userIdentifier);
+        verify(likeRepository, times(1)).deleteByPostAndUserIdentifier(testPost, userIdentifier);
+        verify(postRepository, times(1)).save(testPost);
+    }
+
+    @Test
+    void isLikedByUser_WhenPostNotExists_ShouldReturnFalse() {
+        when(postRepository.findById(1L)).thenReturn(Optional.empty());
+
+        boolean result = likeService.isLikedByUser(1L, userIdentifier);
+
+        assertFalse(result);
+        verify(postRepository, times(1)).findById(1L);
+        verify(likeRepository, never()).existsByPostAndUserIdentifier(any(), any());
+    }
+
+    @Test
+    void isLikedByUser_WhenPostExistsAndLiked_ShouldReturnTrue() {
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+        when(likeRepository.existsByPostAndUserIdentifier(testPost, userIdentifier)).thenReturn(true);
+
+        boolean result = likeService.isLikedByUser(1L, userIdentifier);
+
+        assertTrue(result);
+        verify(postRepository, times(1)).findById(1L);
+        verify(likeRepository, times(1)).existsByPostAndUserIdentifier(testPost, userIdentifier);
+    }
+
+    @Test
+    void isLikedByUser_WhenPostExistsAndNotLiked_ShouldReturnFalse() {
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+        when(likeRepository.existsByPostAndUserIdentifier(testPost, userIdentifier)).thenReturn(false);
+
+        boolean result = likeService.isLikedByUser(1L, userIdentifier);
+
+        assertFalse(result);
+        verify(postRepository, times(1)).findById(1L);
+        verify(likeRepository, times(1)).existsByPostAndUserIdentifier(testPost, userIdentifier);
+    }
+
+    @Test
+    void getLikeCount_ShouldReturnCorrectCount() {
+        when(likeRepository.countByPostId(1L)).thenReturn(5L);
+
+        long result = likeService.getLikeCount(1L);
+
+        assertEquals(5L, result);
+        verify(likeRepository, times(1)).countByPostId(1L);
+    }
+
+    @Test
+    void getLikeCount_WhenNoLikes_ShouldReturnZero() {
+        when(likeRepository.countByPostId(1L)).thenReturn(0L);
+
+        long result = likeService.getLikeCount(1L);
+
+        assertEquals(0L, result);
+        verify(likeRepository, times(1)).countByPostId(1L);
+    }
+}

--- a/src/test/java/com/run/runners/service/PostServiceTest.java
+++ b/src/test/java/com/run/runners/service/PostServiceTest.java
@@ -1,0 +1,193 @@
+package com.run.runners.service;
+
+import com.run.runners.entity.Post;
+import com.run.runners.repository.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private PostService postService;
+
+    private Post testPost;
+
+    @BeforeEach
+    void setUp() {
+        testPost = new Post();
+        testPost.setId(1L);
+        testPost.setTitle("테스트 제목");
+        testPost.setContent("테스트 내용");
+        testPost.setAuthor("테스트 작성자");
+        testPost.setViewCount(0);
+        testPost.setLikeCount(0);
+        testPost.setCreatedAt(LocalDateTime.now());
+        testPost.setUpdatedAt(LocalDateTime.now());
+    }
+
+    @Test
+    void savePost_ShouldReturnSavedPost() {
+        when(postRepository.save(any(Post.class))).thenReturn(testPost);
+
+        Post result = postService.savePost(testPost);
+
+        assertNotNull(result);
+        assertEquals(testPost.getId(), result.getId());
+        assertEquals(testPost.getTitle(), result.getTitle());
+        assertEquals(testPost.getContent(), result.getContent());
+        verify(postRepository, times(1)).save(testPost);
+    }
+
+    @Test
+    void getAllPosts_ShouldReturnListOfPosts() {
+        List<Post> posts = Arrays.asList(testPost);
+        when(postRepository.findAllOrderByCreatedAtDesc()).thenReturn(posts);
+
+        List<Post> result = postService.getAllPosts();
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(testPost.getId(), result.get(0).getId());
+        verify(postRepository, times(1)).findAllOrderByCreatedAtDesc();
+    }
+
+    @Test
+    void getPostById_WhenPostExists_ShouldReturnPost() {
+        when(postRepository.findById(1L)).thenReturn(Optional.of(testPost));
+
+        Optional<Post> result = postService.getPostById(1L);
+
+        assertTrue(result.isPresent());
+        assertEquals(testPost.getId(), result.get().getId());
+        verify(postRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void getPostById_WhenPostNotExists_ShouldReturnEmpty() {
+        when(postRepository.findById(1L)).thenReturn(Optional.empty());
+
+        Optional<Post> result = postService.getPostById(1L);
+
+        assertFalse(result.isPresent());
+        verify(postRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void getPostByIdAndIncrementView_WhenPostExists_ShouldIncrementViewAndReturnPost() {
+        Post updatedPost = new Post();
+        updatedPost.setId(1L);
+        updatedPost.setTitle("테스트 제목");
+        updatedPost.setContent("테스트 내용");
+        updatedPost.setAuthor("테스트 작성자");
+        updatedPost.setViewCount(1);
+        updatedPost.setLikeCount(0);
+
+        when(postRepository.findById(1L))
+            .thenReturn(Optional.of(testPost))
+            .thenReturn(Optional.of(updatedPost));
+
+        Optional<Post> result = postService.getPostByIdAndIncrementView(1L);
+
+        assertTrue(result.isPresent());
+        assertEquals(1, result.get().getViewCount());
+        verify(postRepository, times(1)).incrementViewCount(1L);
+        verify(postRepository, times(2)).findById(1L);
+    }
+
+    @Test
+    void getPostByIdAndIncrementView_WhenPostNotExists_ShouldReturnEmpty() {
+        when(postRepository.findById(1L)).thenReturn(Optional.empty());
+
+        Optional<Post> result = postService.getPostByIdAndIncrementView(1L);
+
+        assertFalse(result.isPresent());
+        verify(postRepository, never()).incrementViewCount(anyLong());
+        verify(postRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void searchByTitle_ShouldReturnMatchingPosts() {
+        List<Post> posts = Arrays.asList(testPost);
+        when(postRepository.findByTitleContainingIgnoreCaseOrderByCreatedAtDesc("테스트")).thenReturn(posts);
+
+        List<Post> result = postService.searchByTitle("테스트");
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(testPost.getId(), result.get(0).getId());
+        verify(postRepository, times(1)).findByTitleContainingIgnoreCaseOrderByCreatedAtDesc("테스트");
+    }
+
+    @Test
+    void searchByAuthor_ShouldReturnMatchingPosts() {
+        List<Post> posts = Arrays.asList(testPost);
+        when(postRepository.findByAuthorContainingIgnoreCaseOrderByCreatedAtDesc("작성자")).thenReturn(posts);
+
+        List<Post> result = postService.searchByAuthor("작성자");
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(testPost.getId(), result.get(0).getId());
+        verify(postRepository, times(1)).findByAuthorContainingIgnoreCaseOrderByCreatedAtDesc("작성자");
+    }
+
+    @Test
+    void searchByTitleOrContent_ShouldReturnMatchingPosts() {
+        List<Post> posts = Arrays.asList(testPost);
+        when(postRepository.findByTitleContainingIgnoreCaseOrContentContainingIgnoreCaseOrderByCreatedAtDesc("키워드", "키워드"))
+            .thenReturn(posts);
+
+        List<Post> result = postService.searchByTitleOrContent("키워드");
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(testPost.getId(), result.get(0).getId());
+        verify(postRepository, times(1))
+            .findByTitleContainingIgnoreCaseOrContentContainingIgnoreCaseOrderByCreatedAtDesc("키워드", "키워드");
+    }
+
+    @Test
+    void deletePost_ShouldCallRepositoryDelete() {
+        doNothing().when(postRepository).deleteById(1L);
+
+        postService.deletePost(1L);
+
+        verify(postRepository, times(1)).deleteById(1L);
+    }
+
+    @Test
+    void updatePost_ShouldReturnUpdatedPost() {
+        Post updatedPost = new Post();
+        updatedPost.setId(1L);
+        updatedPost.setTitle("수정된 제목");
+        updatedPost.setContent("수정된 내용");
+        updatedPost.setAuthor("테스트 작성자");
+
+        when(postRepository.save(any(Post.class))).thenReturn(updatedPost);
+
+        Post result = postService.updatePost(updatedPost);
+
+        assertNotNull(result);
+        assertEquals("수정된 제목", result.getTitle());
+        assertEquals("수정된 내용", result.getContent());
+        verify(postRepository, times(1)).save(updatedPost);
+    }
+}


### PR DESCRIPTION
## Summary
- PostService와 LikeService에 대한 JUnit 단위테스트 추가
- 게시물 CRUD 및 좋아요 기능에 대한 테스트 케이스 구현
- Mockito를 활용한 의존성 모킹 테스트

## Test plan
- [x] PostService 테스트: 게시물 저장, 조회, 수정, 삭제, 검색 기능
- [x] LikeService 테스트: 좋아요 토글, 좋아요 상태 확인, 좋아요 수 조회 기능
- [x] 모든 테스트 케이스 통과 확인

🤖 Generated with [Claude Code](https://claude.ai/code)